### PR TITLE
Fix incompatible werkzeug version

### DIFF
--- a/requierments.txt
+++ b/requierments.txt
@@ -5,3 +5,4 @@ beautifulsoup4
 requests[socks]
 requests_html
 schedule
+Werkzeug==2.2.2


### PR DESCRIPTION
Fix error on werkzeug 3.0:
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/opt/ytdlp2STRM/venv/lib/python3.11/site-packages/werkzeug/urls.py)