### PR TITLE
Fix streams channel config getting stuck in loop

### DIFF
--- a/plugins/youtube/youtube.py
+++ b/plugins/youtube/youtube.py
@@ -42,17 +42,20 @@ class Youtube:
                     self.videos = self.get_videos()
 
     def get_id(self):
+        base_channel_url = self.channel_url
+        if 'streams' in base_channel_url:
+            base_channel_url = base_channel_url[:base_channel_url.index('streams')]
         command = [
-            'yt-dlp', 
+            'yt-dlp',
             '--compat-options', 'no-youtube-channel-redirect',
             '--compat-options', 'no-youtube-unavailable-videos',
             '--restrict-filenames',
             '--ignore-errors',
             '--no-warnings',
-            '--playlist-start', '1', 
-            '--playlist-end', '1', 
-            '--print', 'channel_url', 
-            self.channel_url
+            '--playlist-start', '1',
+            '--playlist-end', '1',
+            '--print', 'channel_url',
+            base_channel_url
         ]
 
         print(' '.join(command))


### PR DESCRIPTION
I just started using your library and while using the command, python3 cli.py --media youtube --params redirect, the process was getting stuck in loop while trying to get the channel ID at the following command:

yt-dlp --compat-options no-youtube-channel-redirect --compat-options no-youtube-unavailable-videos --restrict-filenames --ignore-errors --no-warnings --playlist-start 1 --playlist-end 1 --print channel_url https://www.youtube.com/{channel_name}/streams

running it manually showed the following error:
ERROR: [youtube] {stream_id}: This live event will begin in 50 days.

If you are using the streams specific url for a channel and the channel has a planned stream that hasn't started the get_id function will continue to retry in a loop.

My solution is to knock off everything in the channel url from 'stream' on in order to find the base channel ID and let the function move on.