### PR TITLE
Fixed the low video quality problem when serving in direct mode by now serving the manifest/m3u8 file from google directly.

### DIFF
--- a/plugins/youtube/youtube.py
+++ b/plugins/youtube/youtube.py
@@ -12,6 +12,8 @@ from clases.folders import folders as f
 from clases.nfo import nfo as n
 import subprocess
 import threading
+import re
+import urllib.request
 ## -- YOUTUBE CLASS
 class Youtube:
     def __init__(self, channel=False, channel_url=False):
@@ -666,23 +668,21 @@ def to_strm(method):
 ## -- EXTRACT / REDIRECT VIDEO DATA 
 def direct(youtube_id): #Sponsorblock doesn't work in this mode
     s_youtube_id = youtube_id.split('-audio')[0]
-
     command = [
-        'yt-dlp', 
-        '-f', 'best',
-        '--no-warnings',
-        '--get-url', 
+        'yt-dlp', '-j',
         s_youtube_id
     ]
     Youtube().set_proxy(command)
-    if '-audio' in youtube_id:
-        command[2] = 'bestaudio'
-    print(' '.join(command))
-
-    #print(' '.join(command))
-    youtube_url = w.worker(command).output()
+    full_info_json_str = w.worker(command).output()
+    full_info_json = json.loads(full_info_json_str)
+    m3u8_url = ''
+    for fmt in full_info_json["formats"]:
+        if "manifest_url" in fmt.keys():
+            if not fmt["manifest_url"] == None:
+                m3u8_url=fmt["manifest_url"]
+                break
     return redirect(
-        youtube_url, 
+        m3u8_url, 
         code=301
     )
 

--- a/plugins/youtube/youtube.py
+++ b/plugins/youtube/youtube.py
@@ -12,8 +12,6 @@ from clases.folders import folders as f
 from clases.nfo import nfo as n
 import subprocess
 import threading
-import re
-import urllib.request
 ## -- YOUTUBE CLASS
 class Youtube:
     def __init__(self, channel=False, channel_url=False):


### PR DESCRIPTION
I extract the url to the manifest file via `yt-dlp -j` and from there fetching one `manifest_url` out of all formats since they do not differ (as I realized).