### PR TITLE
Fixed typo on the example docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ http://localhost:5001/
 
 ```yaml
 ---
-version: "2.1"
 services:
-ytdlp2strm:
+ ytdlp2strm:
     image: fe80grau/ytdlp2strm
     container_name: ytdlp2STRM
     environment:


### PR DESCRIPTION
Removing the version string since it's not used anymore and added an space below `services:` since its needed